### PR TITLE
Revamp customer management layout and admin console

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,8 +133,8 @@
       <li class="nav-item" data-view="analytics">
         <a href="#"><i class="fas fa-chart-bar"></i> <span>분석 및 리포트</span></a>
       </li>
-      <li class="nav-item" data-view="settings">
-        <a href="#"><i class="fas fa-cog"></i> <span>설정</span></a>
+      <li class="nav-item" data-view="userManagement" id="navUserManagement" style="display:none;">
+        <a href="#"><i class="fas fa-user-shield"></i> <span>사용자 관리</span></a>
       </li>
     </ul>
     
@@ -291,17 +291,34 @@
               <i class="fas fa-file-export"></i> 내보내기
             </button>
           </div>
-          <div class="view-filters">
+          <div class="customer-filter-bar">
             <div class="search-box">
               <i class="fas fa-search"></i>
-              <input type="text" id="customerSearch" placeholder="고객 검색..." oninput="searchCustomers()">
+              <input type="text" id="customerSearch" placeholder="고객 검색..." oninput="applyCustomerFilters()">
             </div>
-            <select id="customerFilter" onchange="filterCustomers()">
-              <option value="">전체 고객</option>
-              <option value="vip">VIP 고객</option>
-              <option value="active">활성 고객</option>
-              <option value="inactive">비활성 고객</option>
-            </select>
+            <div class="filter-group">
+              <label for="companyFilter">회사명</label>
+              <input type="text" id="companyFilter" list="companyOptions" placeholder="회사명 선택 또는 입력" oninput="applyCustomerFilters()">
+              <datalist id="companyOptions"></datalist>
+            </div>
+            <div class="filter-group">
+              <label for="managerFilter">담당자</label>
+              <input type="text" id="managerFilter" list="managerOptions" placeholder="담당자 선택 또는 입력" oninput="applyCustomerFilters()">
+              <datalist id="managerOptions"></datalist>
+            </div>
+            <div class="filter-group">
+              <label for="mainCustomerFilter">주요고객</label>
+              <input type="text" id="mainCustomerFilter" list="mainCustomerOptions" placeholder="Y / N" oninput="applyCustomerFilters()">
+              <datalist id="mainCustomerOptions">
+                <option value="Y"></option>
+                <option value="N"></option>
+              </datalist>
+            </div>
+            <div class="filter-group">
+              <label for="emailFilter">이메일</label>
+              <input type="text" id="emailFilter" list="emailOptions" placeholder="이메일 선택 또는 입력" oninput="applyCustomerFilters()">
+              <datalist id="emailOptions"></datalist>
+            </div>
           </div>
         </div>
 
@@ -312,7 +329,7 @@
     <thead>
       <tr>
         <th><input type="checkbox" id="selectAllCustomers"></th>
-        <th>NO. <i class="fas fa-sort"></i></th>
+        <th class="col-no">NO. <i class="fas fa-sort"></i></th>
         <th>회사명 <i class="fas fa-sort"></i></th>
         <th>담당자 <i class="fas fa-sort"></i></th>
         <th>지역 <i class="fas fa-sort"></i></th>
@@ -320,8 +337,10 @@
         <th>전화2 <i class="fas fa-sort"></i></th>
         <th>이메일 <i class="fas fa-sort"></i></th>
         <th>주요고객 <i class="fas fa-sort"></i></th>
+        <th>등록자 <i class="fas fa-sort"></i></th>
         <th>등록일 <i class="fas fa-sort"></i></th>
-        <th>액션</th>
+        <th>비고 <i class="fas fa-sort"></i></th>
+        <th>편집</th>
       </tr>
     </thead>
     <tbody id="customerTableBody">
@@ -648,66 +667,60 @@
         </div>
       </div>
 
-      <!-- 설정 뷰 -->
-      <div id="settingsView" class="view-content">
-        <div class="settings-tabs">
-          <button class="tab-btn active" onclick="showSettingsTab('profile')">프로필</button>
-          <button class="tab-btn" onclick="showSettingsTab('team')">팀 관리</button>
-          <button class="tab-btn" onclick="showSettingsTab('pipeline')">파이프라인 설정</button>
-          <button class="tab-btn" onclick="showSettingsTab('integration')">연동 설정</button>
-        </div>
-
-        <div class="settings-admin-actions" id="settingsAdminActions">
-          <button id="userManageBtn" class="primary-btn">
-            <i class="fas fa-user-cog"></i> 사용자 관리
-          </button>
-        </div>
-        
-        <div class="settings-content">
-          <div id="profileSettings" class="settings-panel active">
-            <h3>프로필 설정</h3>
-            <div class="form-group">
-              <label>이름</label>
-              <input type="text" id="profileName">
-            </div>
-            <div class="form-group">
-              <label>이메일</label>
-              <input type="email" id="profileEmail" readonly>
-            </div>
-            <div class="form-group">
-              <label>부서</label>
-              <input type="text" id="profileDept">
-            </div>
-            <button class="primary-btn" onclick="saveProfile()">저장</button>
+      <!-- 사용자 관리 뷰 -->
+      <div id="userManagementView" class="view-content">
+        <div class="user-management-page">
+          <div class="user-management-header">
+            <h2><i class="fas fa-user-shield"></i> 사용자 관리</h2>
+            <p>통합 CRM Pro의 계정과 권한을 관리합니다. 이 메뉴는 관리자만 접근할 수 있습니다.</p>
           </div>
-          
-          <div id="teamSettings" class="settings-panel">
-            <h3>팀 관리</h3>
-            <button class="primary-btn mb-3" onclick="inviteTeamMember()">
-              <i class="fas fa-user-plus"></i> 팀원 초대
-            </button>
-            <div id="teamList">
-              <!-- 팀원 목록 -->
+          <div class="user-management-panel">
+            <div class="user-table-wrapper">
+              <table class="user-table">
+                <thead>
+                  <tr>
+                    <th>선택</th>
+                    <th>이메일</th>
+                    <th>이름</th>
+                    <th>부서</th>
+                    <th>권한</th>
+                  </tr>
+                </thead>
+                <tbody id="userTableBody"></tbody>
+              </table>
             </div>
-          </div>
-          
-          <div id="pipelineSettings" class="settings-panel">
-            <h3>파이프라인 설정</h3>
-            <div id="pipelineStages">
-              <!-- 파이프라인 단계 설정 -->
+            <div class="btn-row user-table-actions">
+              <button id="deleteSelectedUsersBtn" class="danger-btn">선택 사용자 삭제</button>
+              <button id="saveUserChangesBtn" class="primary-btn">변경사항 저장</button>
             </div>
-          </div>
-          
-          <div id="integrationSettings" class="settings-panel">
-            <h3>연동 설정</h3>
-            <div class="integration-list">
-              <div class="integration-item">
-                <img src="https://www.google.com/favicon.ico" alt="Google">
-                <div>
-                  <h4>Google Calendar</h4>
-                  <p>캘린더 일정을 동기화합니다</p>
+            <div class="user-management-divider"></div>
+            <div class="user-management-add">
+              <h3>사용자 추가</h3>
+              <p class="user-modal-guide">Firebase Authentication에 등록된 이메일만 추가할 수 있습니다.</p>
+              <div class="user-form-grid">
+                <div class="form-group">
+                  <label>이메일</label>
+                  <input type="email" id="newUserEmail" placeholder="name@example.com">
                 </div>
-                <button class="toggle-btn" onclick="toggleIntegration('google')">연결</button>
+                <div class="form-group">
+                  <label>이름</label>
+                  <input type="text" id="newUserName" placeholder="홍길동">
+                </div>
+                <div class="form-group">
+                  <label>부서</label>
+                  <input type="text" id="newUserDepartment" placeholder="영업팀">
+                </div>
+                <div class="form-group">
+                  <label>권한</label>
+                  <select id="newUserRole">
+                    <option value="user">일반</option>
+                    <option value="manager">매니저</option>
+                    <option value="admin">관리자</option>
+                  </select>
+                </div>
+              </div>
+              <div class="btn-row user-form-actions">
+                <button id="addUserConfirmBtn" class="primary-btn">추가</button>
               </div>
             </div>
           </div>
@@ -907,59 +920,6 @@
   </div>
 </div>
 
-<!-- 사용자 관리 모달 -->
-<div id="userModal" class="modal">
-  <div class="modal-content user-modal">
-    <span class="close" onclick="closeUserModal()">&times;</span>
-    <h2>사용자 관리</h2>
-    <div class="user-table-wrapper">
-      <table class="user-table">
-        <thead>
-          <tr>
-            <th>선택</th>
-            <th>이메일</th>
-            <th>이름</th>
-            <th>부서</th>
-            <th>권한</th>
-          </tr>
-        </thead>
-        <tbody id="userTableBody"></tbody>
-      </table>
-    </div>
-    <div class="btn-row user-table-actions">
-      <button id="deleteSelectedUsersBtn" class="danger-btn">선택 사용자 삭제</button>
-      <button id="saveUserChangesBtn" class="primary-btn">변경사항 저장</button>
-    </div>
-    <hr style="margin:15px 0;">
-    <h3>사용자 추가</h3>
-    <p class="user-modal-guide">Firebase Authentication에 등록된 이메일만 추가할 수 있습니다.</p>
-    <div class="form-group">
-      <label>이메일</label>
-      <input type="email" id="newUserEmail" placeholder="name@example.com">
-    </div>
-    <div class="form-group">
-      <label>이름</label>
-      <input type="text" id="newUserName" placeholder="홍길동">
-    </div>
-    <div class="form-group">
-      <label>부서</label>
-      <input type="text" id="newUserDepartment" placeholder="영업팀">
-    </div>
-    <div class="form-group">
-      <label>권한</label>
-      <select id="newUserRole">
-        <option value="user">일반</option>
-        <option value="manager">매니저</option>
-        <option value="admin">관리자</option>
-      </select>
-    </div>
-    <div class="btn-row">
-      <button id="addUserConfirmBtn" class="primary-btn">추가</button>
-      <button onclick="closeUserModal()" class="secondary-btn">닫기</button>
-    </div>
-  </div>
-</div>
-
 <!-- 엑셀 업로드 모달 -->
 <div id="excelModal" class="modal">
   <div class="modal-content">
@@ -968,6 +928,19 @@
       <button id="excelReplaceBtn">기존 삭제 후 업로드</button>
       <button id="excelAppendBtn">추가만</button>
       <button id="excelCancelBtn">취소</button>
+    </div>
+  </div>
+</div>
+
+<!-- 고객 가져오기 모달 -->
+<div id="customerImportModal" class="modal">
+  <div class="modal-content">
+    <h3>가져오기 방식 선택</h3>
+    <p class="modal-description">전체 업로드를 선택하면 기존 고객 데이터가 모두 대체됩니다.</p>
+    <div class="btn-row">
+      <button id="customerImportFullBtn" class="danger-btn">전체 업로드</button>
+      <button id="customerImportPartialBtn" class="primary-btn">부분 업로드</button>
+      <button id="customerImportCancelBtn" class="secondary-btn">취소</button>
     </div>
   </div>
 </div>

--- a/index.html
+++ b/index.html
@@ -340,6 +340,7 @@
         <th>등록자 <i class="fas fa-sort"></i></th>
         <th>등록일 <i class="fas fa-sort"></i></th>
         <th>비고 <i class="fas fa-sort"></i></th>
+        <th>히스토리</th>
         <th>편집</th>
       </tr>
     </thead>
@@ -586,7 +587,12 @@
           <!-- 오른쪽: 커뮤니케이션 이력 -->
           <div class="comm-main">
             <div class="comm-header" id="commHeader">
-              <h3>고객을 선택해주세요</h3>
+              <div class="comm-header-text">
+                <h3>고객을 선택해주세요</h3>
+              </div>
+              <button class="secondary-btn" onclick="openCustomerModal()">
+                <i class="fas fa-user-plus"></i> 고객 추가
+              </button>
             </div>
             <div class="comm-timeline" id="commTimeline">
               <!-- 타임라인 -->
@@ -829,6 +835,8 @@
         <select id="dealCustomer" required>
           <option value="">고객 선택</option>
         </select>
+        <input type="text" id="dealCustomerManual" placeholder="직접 입력 (선택)">
+        <small class="field-hint">목록에 없다면 직접 입력하세요.</small>
       </div>
       <div class="form-group">
         <label>예상 금액</label>
@@ -890,6 +898,8 @@
         <select id="eventCustomer">
           <option value="">고객 선택</option>
         </select>
+        <input type="text" id="eventCustomerManual" placeholder="직접 입력 (선택)">
+        <small class="field-hint">목록에 없다면 직접 입력하세요.</small>
       </div>
       <div class="form-group">
         <label>시작 시간</label>

--- a/index.html
+++ b/index.html
@@ -163,7 +163,7 @@
         <div class="header-actions">
           <button class="icon-btn" onclick="showNotifications()">
             <i class="fas fa-bell"></i>
-            <span class="badge" id="notificationBadge">3</span>
+            <span class="badge" id="notificationBadge">0</span>
           </button>
           <button class="icon-btn" onclick="quickAddCustomer()">
             <i class="fas fa-plus-circle"></i>

--- a/integrated-crm-style.css
+++ b/integrated-crm-style.css
@@ -277,7 +277,12 @@ button {
 /* 메인 레이아웃 */
 .main-layout {
   display: flex;
-  height: 100vh;
+  width: 80vw;
+  height: 80vh;
+  margin: 0 auto;
+  max-width: 100%;
+  max-height: 100vh;
+  overflow: auto;
 }
 
 /* 사이드바 */

--- a/integrated-crm-style.css
+++ b/integrated-crm-style.css
@@ -277,12 +277,12 @@ button {
 /* 메인 레이아웃 */
 .main-layout {
   display: flex;
-  width: 80vw;
-  height: 80vh;
+  width: 100vw;
+  height: 100vh;
   margin: 0 auto;
   max-width: 100%;
   max-height: 100vh;
-  overflow: auto;
+  overflow: hidden;
 }
 
 /* 사이드바 */
@@ -524,6 +524,14 @@ button {
   font-weight: 600;
 }
 
+#notificationBadge {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+}
+
 .user-menu {
   display: flex;
   align-items: center;
@@ -556,6 +564,12 @@ button {
   flex: 1;
   overflow-y: auto;
   padding: 1.5rem;
+}
+
+.content-area .view-content {
+  width: 100%;
+  max-width: min(1600px, 80vw);
+  margin: 0 auto;
 }
 
 .view-content {
@@ -781,7 +795,7 @@ button {
   background-color: white;
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-sm);
-  overflow: hidden;
+  overflow: auto;
 }
 
 .data-table {
@@ -1042,7 +1056,7 @@ button {
   height: calc(100vh - 450px);
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow: auto;
 }
 
 .table-wrapper {
@@ -2754,6 +2768,48 @@ canvas {
   height: calc(100% - 70px);
 }
 
+.notification-item {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.75rem 0.5rem;
+  border-bottom: 1px solid var(--border-color);
+  animation: fadeInUp 0.2s ease;
+}
+
+.notification-item:last-child {
+  border-bottom: none;
+}
+
+.notification-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--highlight-color);
+  color: var(--primary-color);
+  flex-shrink: 0;
+}
+
+.notification-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.notification-message {
+  font-size: 0.9rem;
+  color: var(--text-color);
+  line-height: 1.4;
+}
+
+.notification-time {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
 .no-data {
   text-align: center;
   color: var(--text-muted);
@@ -2794,13 +2850,17 @@ canvas {
   .dashboard-grid {
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   }
-  
+
   .dashboard-charts {
     grid-template-columns: 1fr;
   }
-  
+
   .analytics-grid {
     grid-template-columns: 1fr;
+  }
+
+  .content-area .view-content {
+    max-width: 100%;
   }
 }
 
@@ -2818,6 +2878,10 @@ canvas {
   
   .main-content {
     margin-left: 0;
+  }
+
+  .content-area .view-content {
+    max-width: 100%;
   }
   
   .view-header {

--- a/integrated-crm-style.css
+++ b/integrated-crm-style.css
@@ -1501,18 +1501,27 @@ th[data-field="modifiedDate"], td[data-field="modifiedDate"] { min-width: 120px;
 .comm-header {
   padding: 1.5rem;
   border-bottom: 1px solid var(--border-color);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
 }
 
-.comm-header h3 {
+.comm-header-text h3 {
   font-size: 1.125rem;
   margin: 0 0 0.5rem;
   color: var(--text-color);
 }
 
-.comm-header p {
+.comm-header-text p {
   font-size: 0.875rem;
   color: var(--text-muted);
   margin: 0;
+}
+
+.comm-header .badge {
+  position: static;
+  margin-left: 0.5rem;
 }
 
 .comm-timeline {
@@ -1573,11 +1582,6 @@ th[data-field="modifiedDate"], td[data-field="modifiedDate"] { min-width: 120px;
   font-size: 0.875rem;
   line-height: 1.5;
   margin-bottom: 0.5rem;
-}
-
-.timeline-footer {
-  font-size: 0.75rem;
-  color: var(--text-muted);
 }
 
 .comm-input {
@@ -1722,6 +1726,96 @@ th[data-field="modifiedDate"], td[data-field="modifiedDate"] { min-width: 120px;
 
 .data-table td.main-customer-cell {
   text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.main-customer-cell .badge {
+  position: static;
+  margin: 0;
+}
+
+.customer-info .badge {
+  position: static;
+}
+
+.history-btn {
+  padding: 0.35rem 0.75rem;
+  background-color: var(--light-color);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  font-size: 0.75rem;
+  color: var(--text-color);
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.history-btn:hover {
+  background-color: var(--primary-light);
+  color: var(--primary-color);
+}
+
+.field-hint {
+  display: block;
+  margin-top: 0.25rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.timeline-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.timeline-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.timeline-action-btn {
+  background: none;
+  border: none;
+  color: var(--danger-color);
+  cursor: pointer;
+  font-size: 0.75rem;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.timeline-action-btn:hover {
+  color: #a94442;
+}
+
+.remark-history-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.remark-history-item {
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.remark-history-item:last-child {
+  border-bottom: none;
+}
+
+.remark-history-meta {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin-bottom: 0.35rem;
+}
+
+.deal-owner {
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
 }
 
 .settings-admin-actions {

--- a/integrated-crm-style.css
+++ b/integrated-crm-style.css
@@ -43,7 +43,7 @@ body {
   line-height: 1.5;
   color: var(--text-color);
   background-color: var(--background-color);
-  overflow: hidden;
+  overflow: auto;
 }
 
 /* 유틸리티 클래스 */
@@ -431,7 +431,7 @@ button {
   flex: 1;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow: auto;
   background-color: var(--background-color);
 }
 
@@ -730,10 +730,28 @@ button {
   gap: 0.75rem;
 }
 
-.view-filters {
+.customer-filter-bar {
   display: flex;
-  align-items: center;
+  align-items: flex-end;
+  flex-wrap: wrap;
   gap: 0.75rem;
+}
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 160px;
+}
+
+.filter-group label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.filter-group input {
+  min-height: 38px;
 }
 
 .search-box {
@@ -750,7 +768,7 @@ button {
 
 .search-box input {
   padding-left: 2.5rem;
-  width: 250px;
+  min-width: 220px;
 }
 
 /* 데이터 테이블 */
@@ -1690,6 +1708,17 @@ th[data-field="modifiedDate"], td[data-field="modifiedDate"] { min-width: 120px;
   border-bottom: 2px solid var(--border-color);
 }
 
+.data-table th.col-no,
+.data-table td.col-no {
+  width: 80px;
+  min-width: 80px;
+  text-align: center;
+}
+
+.data-table td.main-customer-cell {
+  text-align: center;
+}
+
 .settings-admin-actions {
   display: none;
   justify-content: flex-end;
@@ -1829,6 +1858,13 @@ th[data-field="modifiedDate"], td[data-field="modifiedDate"] { min-width: 120px;
   overflow-y: auto;
 }
 
+.modal-description {
+  margin-top: -0.5rem;
+  margin-bottom: 1.25rem;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
 .modal-content.modal-lg {
   max-width: 800px;
 }
@@ -1936,44 +1972,49 @@ th[data-field="modifiedDate"], td[data-field="modifiedDate"] { min-width: 120px;
   transform: translateX(4px);
 }
 
-/* 사용자 관리 모달 */
-#userModal .modal-content.user-modal {
-  width: 720px;
-  max-width: 95%;
-  padding: 32px;
+/* 사용자 관리 */
+.user-management-page {
+  background: #fff;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 }
 
-#userModal h2,
-#userModal h3 {
-  margin: 0 0 16px;
+.user-management-header h2 {
+  margin-bottom: 0.5rem;
   color: var(--primary-color);
-  font-weight: 600;
+  font-size: 1.4rem;
 }
 
-#userModal h2 {
-  font-size: 1.4em;
+.user-management-header p {
+  color: var(--text-muted);
+  font-size: 0.95rem;
 }
 
-#userModal h3 {
-  font-size: 1.2em;
-  margin-top: 24px;
+.user-management-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 }
 
-#userModal .form-group {
-  margin-bottom: 16px;
+#userManagementView .form-group {
+  margin-bottom: 0;
 }
 
-#userModal .form-group label {
+#userManagementView .form-group label {
   display: block;
   font-weight: 600;
   margin-bottom: 6px;
   color: #333;
 }
 
-#userModal input[type="text"],
-#userModal input[type="password"],
-#userModal input[type="email"],
-#userModal select {
+#userManagementView input[type="text"],
+#userManagementView input[type="password"],
+#userManagementView input[type="email"],
+#userManagementView select {
   width: 100%;
   padding: 10px 12px;
   border: 1px solid #dce1e6;
@@ -1983,22 +2024,26 @@ th[data-field="modifiedDate"], td[data-field="modifiedDate"] { min-width: 120px;
   background-color: #fff;
 }
 
-#userModal input:focus,
-#userModal select:focus {
+#userManagementView input:focus,
+#userManagementView select:focus {
   border-color: var(--primary-color);
   box-shadow: 0 0 0 3px rgba(49, 91, 138, 0.1);
   outline: none;
 }
 
-#userModal .btn-row {
-  display: flex;
-  gap: 12px;
-  justify-content: flex-end;
-  margin-top: 18px;
+.user-management-divider {
+  height: 1px;
+  background: #e9ecef;
 }
 
-#userModal .btn-row button {
-  min-width: 120px;
+.user-form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.user-form-actions {
+  justify-content: flex-end;
 }
 
 .user-modal-guide {

--- a/integrated-crm-style.css
+++ b/integrated-crm-style.css
@@ -568,8 +568,8 @@ button {
 
 .content-area .view-content {
   width: 100%;
-  max-width: min(1600px, 80vw);
-  margin: 0 auto;
+  max-width: 100%;
+  margin: 0;
 }
 
 .view-content {


### PR DESCRIPTION
## Summary
- replace the legacy settings menu with an admin-only user management view and refresh the layout to use inline management instead of a modal
- expand the customer list with richer filters, centered main-customer badges, new 등록자/비고 columns, and a refined 편집 column layout
- enhance import/export so exports carry headers for round-trip editing and imports offer full versus partial upload modes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d4d60f32b083248446fdee48ae4847